### PR TITLE
Avoid including local vscode configuration into GIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # testing
 /coverage
 
+# IDE
+/.vscode
+
 # production
 
 !/build/frontend/


### PR DESCRIPTION
**Problem**
VsCode stores local configuration in `.vscode`. This configuration may contain absolute paths which are OS dependent. Therefore, it is not transferrable to a different machine or os.

**Solution**
Ignore `.vscode/`.