### PR TITLE
Correct typo in propTypes of GraphY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ epics/gateway/GATEWAY.pvlist
 users/users.json
 users/pvAccess.json
 users/SECRET_PWD_KEY
+
+#IDE
+/.vscode

--- a/ReactApp/src/components/BaseComponents/GraphY.js
+++ b/ReactApp/src/components/BaseComponents/GraphY.js
@@ -536,9 +536,9 @@ GraphY.propTypes = {
    */
   displayModeBar: PropTypes.bool,
   /** Custom y axis minimum to be used,if not defined the graph will auto-scale */
-  ymin: PropTypes.number,
+  yMin: PropTypes.number,
   /** Custom y axis maximum to be used,if not defined the graph will auto-scale */
-  ymax: PropTypes.number,
+  yMax: PropTypes.number,
 
   /** If defined, then the DataConnection debugging information will be displayed*/
   debug: PropTypes.bool,


### PR DESCRIPTION
**Problem**
`GraphY.propTypes` lists properties `ymin` and `ymax`. However, code uses properties `yMin` and `yMax`.

**Solution**
* This fix corrects property names in `GraphY.propTypes`. It looks like the strings `ymin` and `ymax` are not with `GraphY`.
* This fix adds VSCode configuration into ignored GIT files.

**Test**
* This fix was tested by running `docker-compose -f docker-compose-dev-styleguide-dev.yml up` and opening the mobile demo.