### PR TITLE
62 pages build and deployment is failing

### DIFF
--- a/ReactApp/src/components/AlarmHandler/AlarmHandler.md
+++ b/ReactApp/src/components/AlarmHandler/AlarmHandler.md
@@ -1,5 +1,6 @@
 Sample usage:
 
+{% raw %}
 ```js static
 import React from 'react';
 import AlarmHandler from '../AlarmHandler/AlarmHandler'
@@ -20,3 +21,4 @@ const AlarmHandlerDemo = () => {
 
 export default AlarmHandlerDemo;
 ```
+{% endraw %}

--- a/ReactApp/src/components/ArchiverDataViewer/ArchiverDataViewer.md
+++ b/ReactApp/src/components/ArchiverDataViewer/ArchiverDataViewer.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 Example trace prop:
 ```js static
 
@@ -39,7 +41,6 @@ Example yAxes prop:
         }
 
 ```
-
 
 ```js
 import ToggleButton from '../../components/BaseComponents/ToggleButton.js';
@@ -100,6 +101,4 @@ import ThumbWheel from '../../components/BaseComponents/ThumbWheel.js';
     </div>
 </div>
 ```
-
-
-
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/ActionButton.md
+++ b/ReactApp/src/components/BaseComponents/ActionButton.md
@@ -1,15 +1,15 @@
+{% raw %}
 
-  ActionButton EPICS BO example:
+ActionButton EPICS BO example:
 
 ```js
 {/*The TextOuput code is included for demonstration purposes only*/}  
 {/*Only the the JSX code between the hashes  is required to instantiate the ActionButton */}  
   import TextOutput from './TextOutput';
   <div>
-  <div style={{marginBottom:8}}>
-    <TextOutput  pv='testIOC:BO1'   label='Value of testIOC:BO1'/>
-  </div>
-
+    <div style={{marginBottom:8}}>
+      <TextOutput  pv='testIOC:BO1'   label='Value of testIOC:BO1'/>
+    </div>
 
   <ActionButton
     pv='testIOC:BO1'
@@ -75,4 +75,4 @@ ActionButton to multi variable example:
 {/*###############*/}
 </div>
 ```
-
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/ActionFanoutButton.md
+++ b/ReactApp/src/components/BaseComponents/ActionFanoutButton.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 ActionButton EPICS variable example:
 ```js
@@ -32,3 +32,4 @@ ActionButton EPICS variable example:
 {/*###############*/}
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/BitIndicators.md
+++ b/ReactApp/src/components/BaseComponents/BitIndicators.md
@@ -1,5 +1,6 @@
-BitIndicators EPICS variable example:
+{% raw %}
 
+BitIndicators EPICS variable example:
 ```js
 {/*The TextInput code is included for demonstration purposes only*/}  
 {/*Only the the JSX code between the hashes  is required to instantiate the BitIndicators */}  
@@ -9,7 +10,6 @@ BitIndicators EPICS variable example:
   pv='$(device):mbboTest1' macros={{'$(device)':'testIOC','$(id)':'2'}}
   label={"Byte Value"}
   labelPlacement={"top"}
-  
   />
   <br/><br/>
   {/*###############*/}  
@@ -143,3 +143,4 @@ BitIndicators example connection to a SoftChannel EPICS AI pv with example overr
 
   </div>
 ```
+{% raw %}

--- a/ReactApp/src/components/BaseComponents/BitIndicators.md
+++ b/ReactApp/src/components/BaseComponents/BitIndicators.md
@@ -143,4 +143,4 @@ BitIndicators example connection to a SoftChannel EPICS AI pv with example overr
 
   </div>
 ```
-{% raw %}
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/CheckBox.md
+++ b/ReactApp/src/components/BaseComponents/CheckBox.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 CheckBox example connection to a SoftChannel EPICS AI pv with use of EPICS label and a custom label position:
 
@@ -33,3 +33,4 @@ CheckBox example connection to a SoftChannel EPICS AI pv with use of EPICS label
 {/*###############*/}  
   </React.Fragment>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/Gauge.md
+++ b/ReactApp/src/components/BaseComponents/Gauge.md
@@ -1,23 +1,17 @@
-
-
-
+{% raw %}
 
 Gauge example connection to a SoftChannel EPICS AI pv with usePvMinMax:
 
 ```js
 {/*The Slider code is included for demonstration purposes only*/}  
 {/*Only the the JSX code between the hashes  is required to instantiate the Gauge */}  
-  import Slider from './Slider';
+import Slider from './Slider';
 
-  <div style={{width:'50%'}}>
-
+<div style={{width:'50%'}}>
   {/*###############*/}  
-
   <Gauge  pv='$(device):test$(id)' macros={{'$(device)':'testIOC','$(id)':'2'}} usePvMinMax={true}/>
-
   {/*###############*/}
-
-
-<Slider pv='$(device):test$(id)' macros={{'$(device)':'testIOC','$(id)':'2'}}   label='Value:' usePvMinMax={true} step={1}/>
+  <Slider pv='$(device):test$(id)' macros={{'$(device)':'testIOC','$(id)':'2'}}   label='Value:' usePvMinMax={true} step={1}/>
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/GraphY.md
+++ b/ReactApp/src/components/BaseComponents/GraphY.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 GraphY EPICS variable example, drag the slider to modulate the amplitude of the Sine Wave:
 ```js
@@ -91,12 +91,9 @@ import Slider from './Slider';
     legend={['Sine Wave Amplitude']}
     yMin={3000}
     yMax={6000}
-
-
   />
 </div>
   <Slider  pv='testIOC:amplitude'   label='Sine Wave Amplitude' usePvMinMax={true}/>
 </div>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/LightPanel.md
+++ b/ReactApp/src/components/BaseComponents/LightPanel.md
@@ -1,3 +1,4 @@
+{% raw %}
 LightPanel example:
 
 ```js
@@ -95,3 +96,4 @@ import TextInput from "./TextInput";
   {/*###############*/}
 </React.Fragment>;
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/ProgressBar.md
+++ b/ReactApp/src/components/BaseComponents/ProgressBar.md
@@ -1,6 +1,4 @@
-
-
-
+{% raw %}
 
 ProgressBar example connection to a SoftChannel EPICS AI pv with usePvMinMax:
 
@@ -21,3 +19,4 @@ ProgressBar example connection to a SoftChannel EPICS AI pv with usePvMinMax:
 <Slider pv='$(device):test$(id)' macros={{'$(device)':'testIOC','$(id)':'2'}}   label='Value:' usePvMinMax={true} step={1}/>
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/RadioButton.md
+++ b/ReactApp/src/components/BaseComponents/RadioButton.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 RadioButton example connection to a SoftChannel EPICS AI pv with use of EPICS label and a custom label position:
 
@@ -19,17 +19,14 @@ RadioButton example connection to a SoftChannel EPICS AI pv with use of EPICS la
       />
   </div>
 
-
 {/*###############*/}  
-
   <RadioButton
     pv='$(device):BO$(id)'
     macros={{'$(device)':'testIOC','$(id)':'1'}}
     usePvLabel={true}
     labelPosition={"end"}
     />
-
-
 {/*###############*/}  
   </React.Fragment>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/RadioButtonGroup.md
+++ b/ReactApp/src/components/BaseComponents/RadioButtonGroup.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 RadioButtonGroup example connection to a SoftChannel EPICS MBBO pv with horizontal orientation and EPICS pv strings for choice:
 
@@ -51,3 +51,4 @@ RadioButtonGroup example connection to a SoftChannel EPICS MBBO pv with vertical
 
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/SelectionInput.md
+++ b/ReactApp/src/components/BaseComponents/SelectionInput.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 SelectionInput example connection to a SoftChannel EPICS MBBO pv with EPICS pv strings for choice:
 
@@ -63,3 +63,4 @@ SelectionInput example connection to a SoftChannel EPICS MBBO pv with custom str
 
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/SelectionList.md
+++ b/ReactApp/src/components/BaseComponents/SelectionList.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 SelectionList example connection to a SoftChannel EPICS MBBO pv with horizontal orientation and EPICS pv strings for choice:
 
@@ -50,3 +50,4 @@ SelectionList example connection to a SoftChannel EPICS MBBO pv with vertical or
 
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/StyledIconButton.md
+++ b/ReactApp/src/components/BaseComponents/StyledIconButton.md
@@ -1,3 +1,4 @@
+{% raw %}
 
 StyledIconButton example connection to a SoftChannel EPICS AI pv with example of usePvLabel
 
@@ -59,3 +60,4 @@ StyledIconButton example connection to a SoftChannel EPICS AI pv with example of
 
   </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/StyledIconIndicator.md
+++ b/ReactApp/src/components/BaseComponents/StyledIconIndicator.md
@@ -1,6 +1,6 @@
+{% raw %}
 
 StyledIconIndicator with custom icon EPICS variable example:
-
 
 ```js
 {/*The ToggleButton code is included for demonstration purposes only*/}  
@@ -132,3 +132,4 @@ StyledIconIndicator example connection to a SoftChannel EPICS AI pv with example
 
   </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/Switch.md
+++ b/ReactApp/src/components/BaseComponents/Switch.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 Switch example connection to a SoftChannel EPICS AI pv with use of EPICS label and a custom label position:
 
@@ -32,3 +32,4 @@ Switch example connection to a SoftChannel EPICS AI pv with use of EPICS label a
 {/*###############*/}  
   </React.Fragment>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/SwitchComponent.md
+++ b/ReactApp/src/components/BaseComponents/SwitchComponent.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 SwitchComponent example connection to a SoftChannel EPICS AI pv with use of EPICS label and a custom label position:
 
@@ -32,3 +32,4 @@ SwitchComponent example connection to a SoftChannel EPICS AI pv with use of EPIC
 {/*###############*/}  
   </React.Fragment>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/Tank.md
+++ b/ReactApp/src/components/BaseComponents/Tank.md
@@ -1,6 +1,4 @@
-
-
-
+{% raw %}
 
 Tank example connection to a SoftChannel EPICS AI pv with usePvMinMax:
 
@@ -21,3 +19,4 @@ Tank example connection to a SoftChannel EPICS AI pv with usePvMinMax:
 <Slider pv='$(device):test$(id)' macros={{'$(device)':'testIOC','$(id)':'2'}}   label='Value:' usePvMinMax={true} step={1}/>
 </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/TextInput.md
+++ b/ReactApp/src/components/BaseComponents/TextInput.md
@@ -1,3 +1,4 @@
+{% raw %}
 
 TextInput example connection to an SoftChannel EPICS AI pv:
 
@@ -50,10 +51,7 @@ TextInput example connection to an SoftChannel EPICS MBBO pv using the numerical
        macros={{'$(device)':'testIOC','$(id)':'1'}}
        usePvLabel={true}
        usePvUnits={true}
-
     />
-
-
 ```
 
 TextInput example :
@@ -82,4 +80,4 @@ TextInput number format example :
        numberFormat={{notation: 'engineering',precision: 5}}
     />
 ```
-
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/TextOutput.md
+++ b/ReactApp/src/components/BaseComponents/TextOutput.md
@@ -1,3 +1,4 @@
+{% raw %}
 
 TextOutput example connection to an SoftChannel EPICS AI pv:
 
@@ -81,3 +82,4 @@ TextOutput number format example :
        numberFormat={{notation: 'engineering',precision: 5}}
     />
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/TextUpdate.md
+++ b/ReactApp/src/components/BaseComponents/TextUpdate.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 TextUpdate example connection to a SoftChannel EPICS AI pv with custom label, precision and units:
 
@@ -38,3 +38,4 @@ TextUpdate example connection to a SoftChannel EPICS AI pv with EPICS label, pre
    numberFormat={{notation: 'engineering',precision: 2}}
 />
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/ThumbWheel.md
+++ b/ReactApp/src/components/BaseComponents/ThumbWheel.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 ThumbWheel example connection to a SoftChannel EPICS AI pv with custom precision:
 
@@ -19,7 +19,6 @@ ThumbWheel example connection to a SoftChannel EPICS AI pv with custom precision
       prec={3}
       />
   </div>
-
 
 {/*###############*/}  
 
@@ -46,3 +45,4 @@ custom increments example
     custom_increments={[500,50,5,0.5]}
     />
 ```
+{% endraw %}

--- a/ReactApp/src/components/BaseComponents/ToggleButton.md
+++ b/ReactApp/src/components/BaseComponents/ToggleButton.md
@@ -1,27 +1,27 @@
+{% raw %}
+
 ToggleButton EPICS example:
+
 ```js
 import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew';
 {/*The TextOutput code is included for demonstration purposes only*/}  
 {/*Only the the JSX code between the hashes  is required to instantiate the ToggleButton */}  
   import TextOutput from './TextOutput';
   <div>
-  <div style={{marginBottom:8}}>
-    <TextOutput  pv='testIOC:BO1'   label={'Value of: testIOC:BO1 '} useStringValue={true}/>
-  </div>
+    <div style={{marginBottom:8}}>
+      <TextOutput  pv='testIOC:BO1'   label={'Value of: testIOC:BO1 '} useStringValue={true}/>
+    </div>
 
-{/*###############*/}  
-<ToggleButton
-  pv='testIOC:BO1'
-  label={'testIOC:BO1 '}
-  labelPlacement={"top"}
-  muiButtonProps={{startIcon:<PowerSettingsNewIcon />}}
-/>
-{/*###############*/}
-
-
+    {/*###############*/}  
+    <ToggleButton
+      pv='testIOC:BO1'
+      label={'testIOC:BO1 '}
+      labelPlacement={"top"}
+      muiButtonProps={{startIcon:<PowerSettingsNewIcon />}}
+    />
+    {/*###############*/}
   </div>
 ```
-
 
 Momentary ToggleButton EPICS example:
 ```js
@@ -49,3 +49,4 @@ import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew';
 
   </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/ExperimentalExamples/Mobile/DynamicPvFieldExample.md
+++ b/ReactApp/src/components/ExperimentalExamples/Mobile/DynamicPvFieldExample.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 When using EPICS, the RAS pv's metadata is conventionally derived from the pyEpics PV in the pvserver. 
 The pyEpics metadata is unfortunately static and the values used will be the intial values that pvserver receives when it connects the first time. 
 This is sufficient in most cases except when the user wants to dynamically update the metaData.
@@ -19,3 +21,4 @@ In the useMetadata=false case, seperate variables passively write to the EPICS f
     <DynamicPvFieldExample/>
   </div>
 ```
+{% endraw %}

--- a/ReactApp/src/components/ExperimentalSvgBeamlineComponents/SvgComponent.md
+++ b/ReactApp/src/components/ExperimentalSvgBeamlineComponents/SvgComponent.md
@@ -1,10 +1,11 @@
- ``` js
+{% raw %}
+
+``` js
 import BeamLineCanvas from '../SvgBeamlineComponents/BeamLineCanvas';
 import HorizontalBeamline from '../SvgBeamlineComponents/HorizontalBeamline';
 <BeamLineCanvas 
   width={600} 
   height={300} 
-  //debugBorder={true}
   >
     <HorizontalBeamline 
       x={0}
@@ -87,11 +88,8 @@ import HorizontalBeamline from '../SvgBeamlineComponents/HorizontalBeamline';
          
         />
       </g>
-        
       </svg>
     </SvgComponent>
-
-    
   </BeamLineCanvas>
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/LoadSaveComponent/LoadSave.md
+++ b/ReactApp/src/components/LoadSaveComponent/LoadSave.md
@@ -1,9 +1,10 @@
-
-<img src="img/loadSave/loadSave.png" alt="loadSave" width="100%"/> 
+<img src="../../../img/loadSave/loadSave.png" alt="loadSave" width="100%"/> 
 *Fig 1. A screenshot of the LoadSave component.*
 
-<img src="img/loadSave/loadSave2.png" alt="loadSave" width="100%"/> 
+<img src="../../../img/loadSave/loadSave2.png" alt="loadSave" width="100%"/> 
 *Fig 2. A screenshot of the LoadSave component showing the life cycle management buttons.*
+
+{% raw %}
 
 Example: 
 
@@ -87,7 +88,4 @@ Currently only the script can be used to seed the database, in future the client
 
 Once the database is seeded PVs and metadata can be removed or added using MongoDB compass.
 
-
-
-
-
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/BeamLineCanvas.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/BeamLineCanvas.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 ```js
 import HorizontalBeamline from './HorizontalBeamline';
@@ -111,3 +111,4 @@ import SteererXYMagnet from './SteererXYMagnet';
 	
 </BeamLineCanvas>
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/BendingMagnet.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/BendingMagnet.md
@@ -1,4 +1,6 @@
- ``` js
+{% raw %}
+
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSinglePS from '../ControlScreens/Components/EditorSinglePS';
@@ -71,6 +73,5 @@ const [displayEditor,setDisplayEditor]=useState(false);
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/FC.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/FC.md
@@ -1,7 +1,7 @@
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
-
 
 <BeamLineCanvas width={600} height={300} >
        <HorizontalBeamline 
@@ -77,13 +77,9 @@ import HorizontalBeamline from './HorizontalBeamline';
           }
           x={180}
           y={50}
-          
-          alarmSensitive={true}
-         
-        
+          alarmSensitive={true}        
           componentGradient={true}
         />
-      
-        </BeamLineCanvas>
-
+</BeamLineCanvas>
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/Harp.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/Harp.md
@@ -1,3 +1,4 @@
+{% raw %}
  ``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
@@ -8,11 +9,9 @@ import HorizontalBeamline from './HorizontalBeamline';
           x={0}
           y={50}
           width={'300px'}
-     
         />
        
         <Harp
-
           pv={'$(IOC):$(actuatorName):put-outIn'}
           isMovingPv = {'$(IOC):$(actuatorName):get-status.B5'}
           inLimitPv = {'$(IOC):$(actuatorName):get-status.B6'}
@@ -22,24 +21,17 @@ import HorizontalBeamline from './HorizontalBeamline';
           isMovingValue={1}
           maxHarpsReached={false}
    
-          label= {'$(actuatorName)'}
+          label = {'$(actuatorName)'}
 
-          macros= {{
+          macros = {{
               '$(IOC)': 'testIOC',
               '$(actuatorName)': 'Harp2',
-             
-          }
-          }
+          }}
           x={50}
           y={50}
-          
           alarmSensitive={true}
-         
-        
           componentGradient={true}
         />
-      
-      
-        </BeamLineCanvas>
-
+</BeamLineCanvas>
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/QuadrapoleMagnet.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/QuadrapoleMagnet.md
@@ -1,5 +1,5 @@
-
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSinglePS from '../ControlScreens/Components/EditorSinglePS';
@@ -63,14 +63,12 @@ const [displayEditor,setDisplayEditor]=useState(false);
                 '$(IOC)': 'testIOC',
                 '$(device)': 'PS1',
               },
-              disableLink:true
-          
+              disableLink:true          
           }
           }
           handleCloseEditor={() => setDisplayEditor(false)} 
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/SlitXY.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/SlitXY.md
@@ -1,6 +1,5 @@
-
-
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSlitXY from '../ControlScreens/Components/EditorSlitXY';
@@ -70,14 +69,12 @@ const [displayEditor,setDisplayEditor]=useState(false);
             '$(IOC)': 'testIOC',
             '$(device)': 'SLITXY1',
           },
-              disableLink:true
-          
+              disableLink:true          
           }
           }
           handleCloseEditor={() => setDisplayEditor(false)} 
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/SteererXMagnet.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/SteererXMagnet.md
@@ -1,6 +1,5 @@
-
-
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSinglePS from '../ControlScreens/Components/EditorSinglePS';
@@ -68,13 +67,11 @@ const [displayEditor,setDisplayEditor]=useState(false);
               '$(XorY)': 'X'
             },
             disableLink:true
-          
           }
           }
           handleCloseEditor={() => setDisplayEditor(false)} 
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/SteererXYMagnet.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/SteererXYMagnet.md
@@ -1,7 +1,5 @@
-
-
-
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSteererXY from '../ControlScreens/Components/EditorSteererXY';
@@ -69,6 +67,5 @@ const [displayEditor,setDisplayEditor]=useState(false);
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SvgBeamlineComponents/SteererYMagnet.md
+++ b/ReactApp/src/components/SvgBeamlineComponents/SteererYMagnet.md
@@ -1,6 +1,5 @@
-
-
- ``` js
+{% raw %}
+``` js
 import BeamLineCanvas from './BeamLineCanvas';
 import HorizontalBeamline from './HorizontalBeamline';
 import EditorSinglePS from '../ControlScreens/Components/EditorSinglePS';
@@ -75,6 +74,5 @@ const [displayEditor,setDisplayEditor]=useState(false);
         />}
       </Grid>
     </Grid>
-
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/SystemComponents/PV.md
+++ b/ReactApp/src/components/SystemComponents/PV.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 The pv object return through the pvData callback or passed to the child function has a default structure with the following properties:
 ```js static
 {
@@ -33,7 +35,6 @@ The pv object return through the pvData callback or passed to the child function
 |enum_strs|array|[]| An array of enumerator strings, if the pv is an enumerator type, valid after initialized===true
 
 Example 1: Raising the pv state using pvData function
-
 ```js
 import React, { useState } from 'react'
 const Example1=(props)=>{
@@ -291,3 +292,4 @@ return(
     macros={{'$(device)':'testIOC'}} 
 />
 ```
+{% endraw %}

--- a/ReactApp/src/components/SystemComponents/Widgets/Widget.md
+++ b/ReactApp/src/components/SystemComponents/Widgets/Widget.md
@@ -1,7 +1,9 @@
+{% raw %}
+
 The props that are forwarded to he child component are detailed in the table below:
 
 | Forwarded Props |Type |Default | Description |
-|:-:|:-|
+| :-: | :- | :- | :- |
 |props|object|| all the props provided to the widget as describe in the props&methods section below.
 |initialized|bool|false|true if all the pvs specified in the pv and pvs props are initialized, and all the forwarded props are valid,
 |pvName|string|""| The name of the pv after the macros have been applied. Valid after initialization.
@@ -67,5 +69,5 @@ Example.defaultProps = {
 };
 
 export default withStyles(styles, { withTheme: true })(Example)
-
 ```
+{% endraw %}

--- a/ReactApp/src/components/UI/Layout/ComposedLayouts/TraditionalLayoutEx1.md
+++ b/ReactApp/src/components/UI/Layout/ComposedLayouts/TraditionalLayoutEx1.md
@@ -1,4 +1,4 @@
-
+{% raw %}
 
 TraditionalLayout with styled app bar, footer and custom footerContent.
 ```js
@@ -23,9 +23,8 @@ const footerContents=(
             </Grid>
         </Grid>
     </Grid>
-)
+);
 
-;
 <TraditionalLayout
     title="My App Title"
     alignTitle="center"
@@ -37,3 +36,4 @@ const footerContents=(
     <Content/>   
 </TraditionalLayout>
 ```
+{% endraw %}

--- a/ReactApp/src/docs/layout/layoutExamples/Mobile.md
+++ b/ReactApp/src/docs/layout/layoutExamples/Mobile.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 When creating more complex layouts or mobile layouts we recommend you stack the grid as a column of rows. This ensures that each row expands to the height of the highest component in that row. This is illustrated below.
 
 ```js
@@ -6,3 +8,4 @@ When creating more complex layouts or mobile layouts we recommend you stack the 
     <Mobile/>
   </div>
 ```
+{% endraw %}


### PR DESCRIPTION
Closes #62 

**Problem**

Deployment of GitHub pages is failing due to treating `{{` in source code as a tag.

**Solution**
* This update uses `{% raw %}` in order to turn off the interpretation of `{{`.
* This update corrects a tags at a table.
* This update corrects location of images `LoadSave.md`.

**Test**

This is a documentation formatting update only. No functional code change. Result has been verifies using github.