### PR TITLE
62 pages build and deployment is failing update config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+exclude:
+  - ReactApp/

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 exclude:
-  - ReactApp/
+  - ReactApp/src


### PR DESCRIPTION
Closes #62 

**Problem**

Build of pages is failing because GitHub generator tries to interpret "{{" as tag in examples inside MD files of the style guide.

**Analysis**

Jeckyl processes every MD in the source tree it can find while building GitHub pages. At the same time, RAS Style Guide uses MD files as source. "{{" is used in code examples in MDs inside Style Guide. Unfortunately, masking "{{" requires a tag {% raw %} which appears at the output of the Style Guide. Fortunately, the Style Guide MDs are not used by or referenced from README.md in the root. Therefore, it is possible to exclude Style Guide only content folder from the gage generation and allow style guide and GitHub pages to coexists.

**Solution**

Exclude "ReactApp/src" from source tree parsed by Jekyll. This allows referencing images from the README.md at the root while it prevents Jekyll from interpreting the MD files meant for the styleguide while building GitHub pages. README.md seems to contain artifacts (e.g. `** New**` instead of `**New**` or HTML tags) which seems to cause Jekyll to pass the content to the output without interpreting. However, the update to README.me is outside scope of this issue.

**Test**

The branch "62-pages-build-and-deployment-is-failing-update-config" has been used to build GitHub pages (see report https://github.com/React-Automation-Studio/React-Automation-Studio/actions/runs/2691068481 and resulting pages at https://react-automation-studio.github.io/React-Automation-Studio/). 

