### PR TITLE
89 automatic build of pages fails due to in readmemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,8 +534,8 @@ Minor Bug Fixes and Updates:
   <li>General clean up of code formatting in both pvServer and React (prior upgrading the MUI library)</li>
   <li>Addition of Poetry as Python package manager</li>
   <li>Addition of Black as a formating tool for Python. A merge request will fail if Python is not formatted accordingly. The tool Black is included into development section of Poetry.</li>
-  <li>Restoration of GitHub pages build. The build excludes documents used with the style guide due to use of "{{"
-    in examples.
+  <li>Restoration of GitHub pages build. The build excludes style guide documents because they include
+    double braces ({) in examples which are treated as an output markup by Liquid.
   </li>
   <li>Minor documentation clean up: links to repositories/ projects up to date.</li>
 </ul>

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
 exclude:
   - ReactApp/src
-markdown: GFM

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
 exclude:
   - ReactApp/src
+markdown: GFM


### PR DESCRIPTION
Closes #89 

**Problem**

GitHub page build fails due to presence of {{.

**Solution**

Update wording in order to avoid {{.

**Test**

This update has been tested by building and deploying GitHub pages (see deployment at https://github.com/React-Automation-Studio/React-Automation-Studio/deployments?environment=github-pages#activity-log)
