### PR TITLE
99 - ReactApp: Slider.js triggers a warning about use of "!=" instead of "!=="

### DIFF
--- a/ReactApp/src/components/BaseComponents/Slider.js
+++ b/ReactApp/src/components/BaseComponents/Slider.js
@@ -440,10 +440,9 @@ function SliderComponent(props) {
                   min={props.initialized ? parseFloat(min) : undefined}
                   max={props.initialized ? parseFloat(max) : undefined}
                   marks={props.initialized ? marks : undefined}
-                  // eslint-disable-next-line eqeqeq
                   step={
                     props.step !== undefined
-                      ? props.step != 0
+                      ? props.step != 0 // eslint-disable-line eqeqeq
                         ? props.step
                         : undefined
                       : undefined


### PR DESCRIPTION
Closes #99

**Problem**

Build reports a warning while building an application based on ReactApp.

**Analysis**

The eslint directive `eslink-disable-next-line` seems to apply only to the next line. Recently, the code has  been modified in order to improve readability. While doing so, the line has been split. As a consequence, the sequence which uses the eslint directive was shifted a line lower. As a consequence, the directive no longer applied to it and the build reported an error.

**Solution**

The directive has been moved down. No code was changed.

**Test**

There should be no code change. Nevertheless, I run docker-compose with `docker-compose-dev` and open "MOBILE DEMO 1" and "MOBILE DEMO 2".
