### PR TITLE
Removed unused style definition

### DIFF
--- a/ReactApp/src/components/SystemComponents/ContextMenu.js
+++ b/ReactApp/src/components/SystemComponents/ContextMenu.js
@@ -23,9 +23,6 @@ const styles = theme => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
-  ConnecedIcon:{
-    backgroundColorcolor:theme.palette.primary.main,
-  },
 });
 
 class ContextMenu extends React.Component {


### PR DESCRIPTION
Closes #100 

**Problem**

Occasionally, browser complains about an unknown property `background-colorcolor`.

**Analysis**

`ContextMenu.js` contains a typo in a property name. And, the parent object of the property is not used any more.

**Solution**

This fix remove the style `ConncedIcon` which uses the unknown property.

**Test**

This fix was tested by starting docker-compose-dev.yml and opening a context menu. No property related warning has been reported in the browser console (Firefox, Linux).