### PR TITLE
108 replace react google login with react oauthgoogle

### DIFF
--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -22,7 +22,7 @@
         "react": "18.2.0",
         "react-device-detect": "2.2.2",
         "react-dom": "18.2.0",
-        "react-google-login": "5.2.2",
+        "@react-oauth/google":"0.6.0",
         "react-plotly.js": "2.6.0",
         "react-router-dom": "5.3.3",
         

--- a/ReactApp/src/components/SystemComponents/Login.js
+++ b/ReactApp/src/components/SystemComponents/Login.js
@@ -24,7 +24,7 @@ import InputAdornment from "@mui/material/InputAdornment";
 import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
 import axios from "axios";
-import { GoogleLogin } from "react-google-login";
+import { GoogleLogin } from "@react-oauth/google";
 import { Container } from "@mui/material";
 
 const Transition = React.forwardRef(function Transition(props, ref) {
@@ -130,7 +130,9 @@ const Login = (props) => {
   const location = useLocation();
 
   const responseGoogle = (response) => {
-    const token = response.tokenId;
+   
+    const token = response.credential;
+    console.log(token)
     const options = {
       headers: { "Content-Type": "application/json" },
       timeout: props.timeout,
@@ -376,13 +378,11 @@ const Login = (props) => {
           {enableGoogleLogin && (
             <div style={{ paddingTop: 24 }}>
               <GoogleLogin
-                clientId={process.env.REACT_APP_EnableGoogleLoginId}
-                buttonText="Login"
+                
                 onSuccess={responseGoogle}
-                onFailure={(response) => {
-                  console.log("google login failed", response);
+                onError={() => {
+                  console.log('Login Failed');
                 }}
-                cookiePolicy={"single_host_origin"}
               />
             </div>
           )}

--- a/ReactApp/src/components/SystemComponents/Login.js
+++ b/ReactApp/src/components/SystemComponents/Login.js
@@ -132,7 +132,6 @@ const Login = (props) => {
   const responseGoogle = (response) => {
    
     const token = response.credential;
-    console.log(token)
     const options = {
       headers: { "Content-Type": "application/json" },
       timeout: props.timeout,

--- a/ReactApp/src/components/SystemComponents/RasAppCore.js
+++ b/ReactApp/src/components/SystemComponents/RasAppCore.js
@@ -9,7 +9,7 @@ import AutomationStudioContext from './AutomationStudioContext';
 import { io } from 'socket.io-client';
 import RasCssBaseline from './RasCssBaseline';
 import PropTypes from 'prop-types';
-
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import axios from 'axios';
 
 class RasAppCore extends Component {
@@ -330,6 +330,7 @@ class RasAppCore extends Component {
     const { system } = this.state;
 
     return (
+      <GoogleOAuthProvider clientId={process.env.REACT_APP_EnableGoogleLoginId}>
       <AutomationStudioContext.Provider value={{ ...system }}>
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={this.state.theme}>
@@ -340,6 +341,7 @@ class RasAppCore extends Component {
           </ThemeProvider>
         </StyledEngineProvider>
       </AutomationStudioContext.Provider>
+      </GoogleOAuthProvider>
     );
   }
 }

--- a/pvServer/pyproject.toml
+++ b/pvServer/pyproject.toml
@@ -19,7 +19,7 @@ python-dotenv = "0.20.0"
 Flask-Cors = "3.0.10"
 Flask-SocketIO = "5.1.2"
 PyJWT = "1.7.1"
-google-api-python-client = "2.47.0"
+google-api-python-client = "2.73.0"
 gevent-websocket = "0.10.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Closes #108

Current version of google sign in is being deprecated.

https://developers.googleblog.com/2021/08/gsi-jsweb-deprecation.html

Solution is to replace "react-google-login" with @react-oauth/google

Will result in minor breaking change if you are using your own custom login based on the previous  react-google-login
Perhaps we should bump up to 4.1.0?