### PR TITLE
117 textinput component cant handle waveform pv input

### DIFF
--- a/ReactApp/src/components/CompoundComponents/ArrayContainer.js
+++ b/ReactApp/src/components/CompoundComponents/ArrayContainer.js
@@ -61,6 +61,7 @@ function ArrayContainer(props) {
     maxItemsCount,
     itemMinWidth,
     spacing,
+    showIndices
   } = props;
   const [startIdx, setStartIdx] = useState(0);
   const [items, setItems] = useState([]);
@@ -140,6 +141,7 @@ function ArrayContainer(props) {
 
   const recreateSingleChild = (index) => {
     let additionalProps = {};
+    
     if (registers !== undefined && Array.isArray(registers)) {
       additionalProps["index"] = registers[index];
     } else {
@@ -151,7 +153,10 @@ function ArrayContainer(props) {
       registersLabel[index]
     ) {
       additionalProps["label"] = registersLabel[index].toString();
+    }else if(showIndices){
+      additionalProps["label"] = index.toString();
     }
+
     return (
       <div key={index.toString()} className={classes.item}>
         {Children.map(props.children, (child) =>
@@ -240,6 +245,10 @@ ArrayContainer.propTypes = {
    * or a subset of them.
    */
   registersLabel: PropTypes.arrayOf(PropTypes.string),
+   /**
+   * Directive to use the array indices as the labels,unless the registersLabel prop is defined
+   */
+   showIndices: PropTypes.bool,
   /**
    * Directive to display array elements horizontally or vertically aligned.
    */
@@ -247,6 +256,7 @@ ArrayContainer.propTypes = {
   /**
    * Min space width, in percentage, an item can occupy.
    */
+  
   itemMinWidth: (props, propName, componentName) => {
     if (!(props[propName] >= 0 && props[propName] <= 100)) {
       return new Error(
@@ -273,6 +283,7 @@ ArrayContainer.defaultProps = {
   labelPlacement: "top",
   itemMinWidth: 2,
   spacing: 1,
+  showIndices:true
 };
 
 export default ArrayContainer;

--- a/ReactApp/src/components/CompoundComponents/ArrayContainer.js
+++ b/ReactApp/src/components/CompoundComponents/ArrayContainer.js
@@ -246,7 +246,7 @@ ArrayContainer.propTypes = {
    */
   registersLabel: PropTypes.arrayOf(PropTypes.string),
    /**
-   * Directive to use the array indices as the labels,unless the registersLabel prop is defined
+   * Directive to use the array indices as the labels, unless the registersLabel prop is defined
    */
    showIndices: PropTypes.bool,
   /**
@@ -283,7 +283,7 @@ ArrayContainer.defaultProps = {
   labelPlacement: "top",
   itemMinWidth: 2,
   spacing: 1,
-  showIndices:true
+  showIndices: true
 };
 
 export default ArrayContainer;

--- a/ReactApp/src/components/CompoundComponents/ArrayContainer.js
+++ b/ReactApp/src/components/CompoundComponents/ArrayContainer.js
@@ -272,7 +272,7 @@ ArrayContainer.defaultProps = {
   direction: "vertical",
   labelPlacement: "top",
   itemMinWidth: 2,
-  spacing: 0,
+  spacing: 1,
 };
 
 export default ArrayContainer;

--- a/ReactApp/src/components/CompoundComponents/ArrayContainer.md
+++ b/ReactApp/src/components/CompoundComponents/ArrayContainer.md
@@ -1,4 +1,4 @@
-In this example the TextInput component receives a waveform PV.
+In this example the TextOutput component displays the raw contents of a waveform PV.
 
 Reading a binary waveform of 10 elements.
 
@@ -9,14 +9,15 @@ The ArrayContainer does not know how many items there are in the PV value. For t
 ```js
 import { Grid, Typography } from "@mui/material";
 import TextInput from "../BaseComponents/TextInput";
+import TextOutput from "../BaseComponents/TextOutput";
 
 <Grid container spacing={5}>
   <Grid item xs={12}>
-    <Typography algin="center">Standard behavior</Typography>
-    <TextInput pv="testIOC:binaryWaveform" />
+    <Typography algin="center">String Contents of the Waveform</Typography>
+    <TextOutput pv="testIOC:binaryWaveform" />
   </Grid>
   <Grid item xs={12}>
-    <Typography algin="center">ArrayContainer behavior</Typography>
+    <Typography algin="center">ArrayContainer Indexed TextInputs</Typography>
     <ArrayContainer maxItemsCount={10}>
       <TextInput pv="testIOC:binaryWaveform" />
     </ArrayContainer>

--- a/pvServer/pvServer.py
+++ b/pvServer/pvServer.py
@@ -485,10 +485,14 @@ def on_change_value(
                 namespace="/pvServer",
             )
         else:
+            new_char_value = str(char_value)
+            if len(new_char_value) == 0:
+                new_char_value = str(value)
             d = {
                 "pvname": pvname,
                 "newmetadata": "False",
                 "value": list((value)),
+                "char_value": new_char_value,
                 "count": count,
                 "connected": "1",
                 "severity": severity,


### PR DESCRIPTION
close #117 

This updates the documentation to prevent the unintentional use case, I also changed the default prop to inculed a spacing of 1, finally I added another prop to show the array indices by default