### PR TITLE
pin poetry version to 1.8.5 in Dockerfile for consistency

### DIFF
--- a/docker/pvserver/Dockerfile
+++ b/docker/pvserver/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y  \
     lcov valgrind
 COPY ./pvServer/pyproject.toml .
 
-RUN pip install --upgrade pip && pip --no-cache-dir install poetry
+RUN pip install --upgrade pip && pip --no-cache-dir install poetry==1.8.5
 RUN poetry config virtualenvs.create false
 RUN poetry install --without dev
 


### PR DESCRIPTION
There  has been a new major release of poetry. It breaks the docker build, work around is to currently fix the version to 1.8.5, whilst we move to V2.x.x