### PR TITLE
Nullish coalesce operator at EnabledDialog is irrelevant causing eslint warnings

### DIFF
--- a/ReactApp/src/components/AlarmHandler/EnableDialog.jsx
+++ b/ReactApp/src/components/AlarmHandler/EnableDialog.jsx
@@ -163,7 +163,7 @@ const EnableDialog = (props) => {
                 disablePast
                 autoOk={false}
                 // Backwards compatible
-                disabled={!props.data.bridge ?? true}
+                disabled={!props.data.bridge}
                 slotProps={{ textField: { variant: 'standard' } }}
               />
             </LocalizationProvider>


### PR DESCRIPTION
Reason: Even though I skip RAS source base while running eslint, I am getting eslint errors in my CI/CD pipeline from time to time. One of the errors is following:
```
(ssr) warning: The "??" operator here will always return the left operand
                  autoOk={false}
                  // Backwards compatible
                  disabled={!props.data.bridge ?? true}
                                               ^
                  slotProps={{ textField: { variant: 'standard' } }} />
  
  Plugin: vite:esbuild
```

Due to the operator precedence (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence), `!` is evaluated first. As a consequence `??` will never apply. Since the expression has been present there since the file was added, the (probably intended) fallback `true` never applied. In order to keep the behavior the same, this fix removes the `??` with the fallback.