### PR TITLE
GraphY: set autosize flag to true

### DIFF
--- a/ReactApp/src/components/BaseComponents/GraphY.tsx
+++ b/ReactApp/src/components/BaseComponents/GraphY.tsx
@@ -249,6 +249,7 @@ const GraphY = ({
         text: props.title,
       },
       plot_bgcolor: backgroundColor,
+      autosize: true,
       xaxis: {
         domain: domain,
         gridcolor:


### PR DESCRIPTION
At the moment, the GraphY component adjusts its size on window resize event.

Adding `autosize: true` to the plot layout allows the component to adjust its size based on the parent div regardless of the window resize event happening.

Before the change:

https://github.com/user-attachments/assets/b802e979-935c-4470-9228-e6453672a79e

After:


https://github.com/user-attachments/assets/9157f54c-6915-4660-b96f-de2e4775b71f




