### PR TITLE
avoid hardDisabled and user interaction on editMode

### DIFF
--- a/ReactApp/src/components/BaseComponents/ActionButton.tsx
+++ b/ReactApp/src/components/BaseComponents/ActionButton.tsx
@@ -148,5 +148,9 @@ interface ActionButtonProps {
    * Any of the MUI Tooltip props can be applied by defining them as an object.
    */
   tooltipProps?: Record<string, any>;
+  /**
+   * If true, the ActionButton will be in edit mode.
+   */
+  editMode?: boolean;
 }
 export default ActionButton;

--- a/ReactApp/src/components/BaseComponents/BitIndicators.tsx
+++ b/ReactApp/src/components/BaseComponents/BitIndicators.tsx
@@ -107,7 +107,7 @@ const BitIndicatorsComponent = (props) => {
       direction={props.horizontal ? "row" : "column"}
     >
       <Grid key={props.label} item xs={12}>
-        {props.initialized ? (
+        {props.initialized || props.editMode ? (
           props.label
         ) : (
           <span>

--- a/ReactApp/src/components/BaseComponents/BitIndicators.tsx
+++ b/ReactApp/src/components/BaseComponents/BitIndicators.tsx
@@ -221,6 +221,10 @@ interface BitIndicatorsProps {
    * The color of the bits when off.
    */
   offColor?: string;
+  /**
+   * If true, the BitIndicators will be in edit mode.
+   */
+  editMode?: boolean;
 
 }
 

--- a/ReactApp/src/components/BaseComponents/CheckBox.tsx
+++ b/ReactApp/src/components/BaseComponents/CheckBox.tsx
@@ -111,6 +111,10 @@ interface CheckBoxProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the CheckBox will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default CheckBox;

--- a/ReactApp/src/components/BaseComponents/CheckBox.tsx
+++ b/ReactApp/src/components/BaseComponents/CheckBox.tsx
@@ -23,6 +23,7 @@ const CheckBoxComponent = (props) => {
         marginBottom: "auto",
         marginLeft: "auto",
         marginRight: "auto",
+        pointerEvents: props.editMode ? "none" : "auto"
       }}
       disabled={props.disabled}
       label={props.formControlLabel}

--- a/ReactApp/src/components/BaseComponents/Gauge.tsx
+++ b/ReactApp/src/components/BaseComponents/Gauge.tsx
@@ -288,6 +288,10 @@ interface GaugeProps {
    */
   debug?: boolean;
   /**
+   * If true, the Gauge will be in edit mode.
+   */
+  editMode?: boolean;
+  /**
    * Local variable initialization value. When using loc:// type PVs.
    */
   initialLocalVariableValue?: string;

--- a/ReactApp/src/components/BaseComponents/GraphXY.tsx
+++ b/ReactApp/src/components/BaseComponents/GraphXY.tsx
@@ -738,6 +738,10 @@ interface GraphXYProps {
     * yAxes: Array of y-axis properties, the implementation appears broken and will be fixed in a later release
     */
    yAxes?: any[];
+  /**
+   * If true, the GraphXY will be in edit mode.
+   */
+  editMode?: boolean;
     
 }
 

--- a/ReactApp/src/components/BaseComponents/GraphXY.tsx
+++ b/ReactApp/src/components/BaseComponents/GraphXY.tsx
@@ -576,7 +576,7 @@ const GraphXY = ({
                         displaylogo: false,
                         scrollZoom: false,
                         displayModeBar: props.displayModeBar,
-                        staticPlot: isMobileOnly ? true : false,
+                        staticPlot: isMobileOnly || props.editMode ? true : false,
                         toImageButtonOptions: {
                           format: "svg",
                         },
@@ -585,7 +585,7 @@ const GraphXY = ({
                         displaylogo: false,
                         scrollZoom: false,
                         staticPlot:
-                          isMobileOnly && disableMobileStatic === false
+                          (isMobileOnly && disableMobileStatic === false) || props.editMode
                             ? true
                             : false,
                         toImageButtonOptions: {

--- a/ReactApp/src/components/BaseComponents/GraphY.tsx
+++ b/ReactApp/src/components/BaseComponents/GraphY.tsx
@@ -570,7 +570,7 @@ interface GraphYProps {
    */
   yAxes?: any[];
   /**
-   * set the widget to in editMode
+   * If true, the GraphY will be in edit mode.
    */
   editMode?: boolean;
 }

--- a/ReactApp/src/components/BaseComponents/GraphY.tsx
+++ b/ReactApp/src/components/BaseComponents/GraphY.tsx
@@ -133,6 +133,7 @@ const GraphY = ({
     display: "inline-block",
     width: "100%",
     height: "100%",
+    pointerEvents: editMode ? "none" : "auto"
   },
   maxLength,
   ...props
@@ -401,7 +402,7 @@ const GraphY = ({
                         scrollZoom: false,
                         doubleclick: false,
                         displayModeBar: props.displayModeBar,
-                        staticPlot: isMobileOnly ? true : false,
+                        staticPlot: isMobileOnly || editMode ? true : false,
                         toImageButtonOptions: {
                           format: "svg",
                         },
@@ -411,7 +412,7 @@ const GraphY = ({
                         scrollZoom: false,
 
                         staticPlot:
-                          isMobileOnly && disableMobileStatic === false
+                          (isMobileOnly && disableMobileStatic === false) || editMode
                             ? true
                             : false,
                         toImageButtonOptions: {

--- a/ReactApp/src/components/BaseComponents/LightPanel.tsx
+++ b/ReactApp/src/components/BaseComponents/LightPanel.tsx
@@ -225,6 +225,10 @@ interface LightPanelProps {
    * Material UI Typography variant. Used to change the style of the value string inside the LightPanel.
    */
   variant?: string;
+  /**
+   * If true, the LightPanel will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default LightPanel;

--- a/ReactApp/src/components/BaseComponents/LightPanel.tsx
+++ b/ReactApp/src/components/BaseComponents/LightPanel.tsx
@@ -47,8 +47,8 @@ function LightPanelComponent(props) {
       }
     }
   }
-  /* Print disconnected if PV not initialized */
-  if (!initialized) {
+  /* Print disconnected if PV not initialized and not in edit mode */
+  if (!initialized && !props.editMode) {
     val = "DISCONNECTED";
   }
   return (
@@ -65,7 +65,7 @@ function LightPanelComponent(props) {
         marginLeft: "auto",
         marginRight: "auto",
       }}
-      disabled={!initialized}
+      disabled={!props.editMode || !initialized}
       control={
         <Paper
           variant="outlined"

--- a/ReactApp/src/components/BaseComponents/ProgressBar.tsx
+++ b/ReactApp/src/components/BaseComponents/ProgressBar.tsx
@@ -302,7 +302,7 @@ const ProgressBarInternalComponent = (props) => {
     max = props.max;
   } else {
     units = "";
-    value = 500;
+    value = props.editMode? 0 : 500;
     min = 0;
     max = 1000;
   }
@@ -347,7 +347,7 @@ const ProgressBarInternalComponent = (props) => {
             color={color}
             showValue={props.showValue}
             showTicks={props.showTicks}
-            disabled={props.initialized === true ? undefined : true}
+            disabled={props.initialized === true || props.editMode ? undefined : true}
           />
         </div>
       }

--- a/ReactApp/src/components/BaseComponents/ProgressBar.tsx
+++ b/ReactApp/src/components/BaseComponents/ProgressBar.tsx
@@ -530,6 +530,10 @@ interface ProgressBarProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the ProgressBar will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default ProgressBar;

--- a/ReactApp/src/components/BaseComponents/RadioButton.tsx
+++ b/ReactApp/src/components/BaseComponents/RadioButton.tsx
@@ -110,6 +110,10 @@ interface RadioButtonProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the RadioButton will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 

--- a/ReactApp/src/components/BaseComponents/RadioButtonGroup.tsx
+++ b/ReactApp/src/components/BaseComponents/RadioButtonGroup.tsx
@@ -136,7 +136,10 @@ interface RadioButtonGroupProps {
    * If defined, the color of the radio button.
    */
   onColor?: "primary" | "secondary" | "default" | "error" | "info" | "success" | "warning";
-  
+  /**
+   * If true, the RadioButtonGroup will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default RadioButtonGroup;

--- a/ReactApp/src/components/BaseComponents/SelectionInput.tsx
+++ b/ReactApp/src/components/BaseComponents/SelectionInput.tsx
@@ -157,6 +157,10 @@ interface SelectionInputProps {
    *  If not defined it uses the custom units as defined by the units prop.
    */
   usePvUnits?: boolean;
+  /**
+   * If true, the SelectionInput will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default SelectionInput;

--- a/ReactApp/src/components/BaseComponents/SelectionInput.tsx
+++ b/ReactApp/src/components/BaseComponents/SelectionInput.tsx
@@ -57,7 +57,7 @@ const SelectionInputComponent = (props) => {
       onFocus={props.onUpdateWidgetFocus}
       onBlur={props.onUpdateWidgetBlur}
       onChange={handleChange}
-      label={props.initialized ? props.label : props.disconnectedIcon}
+      label={props.initialized || props.editMode ? props.label : props.disconnectedIcon}
       margin={props.margin}
       variant={props.variant}
       InputProps={inputProps}

--- a/ReactApp/src/components/BaseComponents/SelectionList.tsx
+++ b/ReactApp/src/components/BaseComponents/SelectionList.tsx
@@ -280,6 +280,10 @@ interface SelectionListProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the SelectionList will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default SelectionList;

--- a/ReactApp/src/components/BaseComponents/SelectionList.tsx
+++ b/ReactApp/src/components/BaseComponents/SelectionList.tsx
@@ -194,8 +194,8 @@ const SelectionListComponent = (props) => {
   };
 
   let itemList = getListItems(
-    props.initialized ? props.enumStrs : ["N/A", "Disconnected"],
-    props.initialized ? props.value : "Disconnected"
+    props.initialized || props.editMode ? props.enumStrs : ["N/A", "Disconnected"],
+    props.initialized || props.editMode ? props.value : "Disconnected"
   );
 
   return (

--- a/ReactApp/src/components/BaseComponents/Slider.tsx
+++ b/ReactApp/src/components/BaseComponents/Slider.tsx
@@ -422,7 +422,7 @@ function SliderComponent(props) {
     <>
      
       <div
-        style={{ height: props.height ?? "100%", width: "100%",userSelect: 'none' }}
+        style={{ height: props.height ?? "100%", width: "100%", userSelect: 'none', pointerEvents: props.editMode ? "none" : "auto" }}
         onPointerDownCapture={handleOnClickCapture}
        
       >

--- a/ReactApp/src/components/BaseComponents/Slider.tsx
+++ b/ReactApp/src/components/BaseComponents/Slider.tsx
@@ -525,6 +525,10 @@ interface SliderProps {
    */
   debug?: boolean;
   /**
+   * If true, the Slider will be in edit mode.
+   */
+  editMode?: boolean;
+  /**
    * Width of the component.
    */
   width?: string;

--- a/ReactApp/src/components/BaseComponents/StyledIconButton.tsx
+++ b/ReactApp/src/components/BaseComponents/StyledIconButton.tsx
@@ -120,6 +120,10 @@ interface StyledIconButtonProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the StyledIconButton will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default StyledIconButton;

--- a/ReactApp/src/components/BaseComponents/StyledIconIndicator.tsx
+++ b/ReactApp/src/components/BaseComponents/StyledIconIndicator.tsx
@@ -148,6 +148,10 @@ interface StyledIconIndicatorProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the StyledIconIndicator will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default StyledIconIndicator;

--- a/ReactApp/src/components/BaseComponents/Switch.tsx
+++ b/ReactApp/src/components/BaseComponents/Switch.tsx
@@ -116,6 +116,10 @@ interface SwitchProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the Switch will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default Switch;

--- a/ReactApp/src/components/BaseComponents/Tank.tsx
+++ b/ReactApp/src/components/BaseComponents/Tank.tsx
@@ -488,6 +488,10 @@ interface TankProps {
   tooltipProps?: object;
   /** label placement*/
   labelPlacement?: "start" | "top" | "bottom" | "end";
+  /**
+   * If true, the Tank will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default Tank;

--- a/ReactApp/src/components/BaseComponents/Tank.tsx
+++ b/ReactApp/src/components/BaseComponents/Tank.tsx
@@ -71,6 +71,7 @@ function getTickValues(
 }
 
 interface TankComponentProps {
+  editMode: boolean;
   height: number;
   width: number;
   aspectRatio: number;
@@ -317,11 +318,11 @@ const TankComponent = (props: TankComponentProps) => {
  * The Tank Component is an React-Automation-studio component useful fo displaying levels.
  */
 const Tank = ({
+  editMode = false,
   debug = false,
   alarmSensitive = false,
   min = 0,
   max = 100,
-
   usePvPrecision = false,
   showValue = false,
   aspectRatio = 1,

--- a/ReactApp/src/components/BaseComponents/TextUpdate.tsx
+++ b/ReactApp/src/components/BaseComponents/TextUpdate.tsx
@@ -225,6 +225,10 @@ interface TextUpdateProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the TextUpdate will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default TextUpdate;

--- a/ReactApp/src/components/BaseComponents/TextUpdateMultiplePVs.tsx
+++ b/ReactApp/src/components/BaseComponents/TextUpdateMultiplePVs.tsx
@@ -178,6 +178,10 @@ interface TextUpdateMultiplePVsProps {
    * Array of the process variable names
    */
   pvs: string[];
+  /**
+   * If true, the TextUpdateMultiplePVs will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default TextUpdateMultiplePVs;

--- a/ReactApp/src/components/BaseComponents/ThumbWheel.tsx
+++ b/ReactApp/src/components/BaseComponents/ThumbWheel.tsx
@@ -257,6 +257,10 @@ interface ThumbWheelProps {
    *  Any of the MUI Tooltip props can applied by defining them as an object
    */
   tooltipProps?: object;
+  /**
+   * If true, the ThumbWheel will be in edit mode.
+   */
+  editMode?: boolean;
 }
 
 export default ThumbWheel;

--- a/ReactApp/src/components/BaseComponents/ToggleButton.tsx
+++ b/ReactApp/src/components/BaseComponents/ToggleButton.tsx
@@ -44,7 +44,7 @@ const ToggleButtonComponent = (props) => {
   const { value } = props;
   let momentary = props.momentary !== undefined ? props.momentary : false;
   let text;
-  if (props.initialized) {
+  if (props.initialized || props.editMode) {
     text = props.enumStrs?props.enumStrs[value == 1 ? 1 : 0]:value == 1 ? "ON" : "OFF";
   } else {
     text = "Disconnected";

--- a/ReactApp/src/components/BaseComponents/ToggleButton.tsx
+++ b/ReactApp/src/components/BaseComponents/ToggleButton.tsx
@@ -224,7 +224,10 @@ interface ToggleButtonProps {
    * Custom Selection Strings, use this to define custom strings for the enum values.i.e.["off","on"] or ["closed","open"] or ["disabled","enabled"]
    */
   custom_selection_strings?: string[];
-  
+  /**
+   * If true, the ToggleButton will be in edit mode.
+   */
+  editMode?: boolean;
 
 }
 


### PR DESCRIPTION
- Add editMode prop definition to all BaseComponents 
    - Up to now the editMode prop was being passed using the `{...others}` destructor on the Widget component. Typescript complains about using an implicit/unknown property, and also the behaviour of some of the components depend on this prop, so adding to them all makes it more consistent.

- Disable user interaction on edit mode. While editing, it is not relevant to the user to zoom or pan a plot, neither click buttons or checkboxes. Disable user interaction by setting pointerEvents: "none" when applicable.

- Ommit "DISCONNECTED" strings when applicable.

Part of #144